### PR TITLE
Use pre-generated RSA keys for signing packages

### DIFF
--- a/overlay/usr/local/bin/build.sh
+++ b/overlay/usr/local/bin/build.sh
@@ -88,7 +88,13 @@ changed_aports() {
 setup_system() {
 	sudo sh -c "echo $MIRROR/$(get_release)/main > /etc/apk/repositories"
 	sudo apk -U upgrade -a || apk fix || die "Failed to up/downgrade system"
-	abuild-keygen -ain
+	if [ -z "${PKG_SIGN_KEY:+x}" ]; then
+		abuild-keygen -ain
+	else
+		echo Using pre-generated keys
+		echo -e "${PKG_SIGN_KEY//$/\\n}" > ~/.abuild/drone.rsa
+		echo PACKAGER_PRIVKEY=\"/home/buildozer/.abuild/drone.rsa\" > ~/.abuild/abuild.conf
+	fi
 	sudo sed -i 's/JOBS=[0-9]*/JOBS=$(nproc)/' /etc/abuild.conf
 	mkdir -p "$REPODEST"
 }


### PR DESCRIPTION
Keys are stored as Repository secrets within Drone.
An environment statement similar to the below would need to be added to the build step of the aports .drone.yml:
```
  environment:
    PKG_SIGN_KEY:
      from_secret: pkg_sign_key
```
The secret within the drone console would be named `pkg_sign_key` and would contain the multiline RSA key you want to use such as from ~/.abuild/<email address>.rsa

This would allow adding a step to upload the package post build such as to an AWS S3 container or via scp to a filestore so it can be used on your own systems that container the corressponding public key.

If the required configuraion doesnt exist it will revert to previous behaviour and auto gen keys on build.